### PR TITLE
Replace `--unreferenced` with `--delete-unreferenced-snapshots`

### DIFF
--- a/content/docs/advanced.md
+++ b/content/docs/advanced.md
@@ -157,24 +157,11 @@ to review the snapshots conveniently.
 ## Handling Unused Snapshots
 
 If we want to automatically check that there aren't unused snapshots in a
-project, we can use the `--unreferenced` option:
+project, we can use the `--delete-unreferenced-snapshots` option:
 
 ```
-cargo insta test --unreferenced=delete
+cargo insta test --delete-unreferenced-snapshots
 ```
-
-Alternatively to deleting you can also set the `--unreferenced` flag to
-`reject` or `warn` which will either fail or at least warn if there are
-unused snapshots left.  When set to `auto` it behaves like `delete` locally
-or like `reject` in a CI environment.
-
-```
-cargo insta test --unreferenced=auto
-```
-
-Note that this option is only helpful when running the full set of tests, since
-insta does not control the execution of tests and can't assess whether unused
-tests depend on the unreferenced snapshots.
 
 ## Workspace Root
 

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -117,11 +117,7 @@ with `--`.
 * `--accept-unseen`: like `--accept` but only accept all new (previously unseen) snapshots.
 * `--keep-pending`: do not reject pending snapshots before run.
 * `--force-update-snapshots`: update all snapshots even if they are still matching.  This is useful if insta changed the metadata format.
-* `--unreferenced`: controls what should happen with unreferenced snapshots.  The default
-  is `ignore`. Valid values are `ignore`, `warn`, `reject`, `delete` and `auto`.
-  `warn` will emit a warning if there are unreference snapshots, `reject` will
-  error. `delete` will delete unreferenced snapshots after the test run.  Finally
-  `auto` behaves like `reject` in CI and like `delete` if not run from CI.
+* `--delete-unreferenced-snapshots`: deletes all unreferenced snapshots after a test run
 * `--glob-filter`: Filters to apply to the insta glob feature
 * `--test-runner`: Selects a different test runner (`cargo-test` or `nextest`)
 


### PR DESCRIPTION
The `--unreferenced` flag has effectively been replaced with `--delete-unreferenced-snapshots` as far as I can tell. This PR updates any reference of the outdated flag.