### PR TITLE
Add how to change snapshot save location

### DIFF
--- a/content/docs/snapshot-types.md
+++ b/content/docs/snapshot-types.md
@@ -10,7 +10,9 @@ are placed as separate `.snap` files, the latter are stored inline in string
 literals in the `.rs` files.
 
 File snapshots are stored in the `snapshots` folder right next to the test file
-where this is used. The name of the file is `<module>__<name>.snap` where
+where this is used (or in a user defined location by
+[changing settings](https://docs.rs/insta/latest/insta/struct.Settings.html#method.snapshot_path)). 
+The name of the file is `<module>__<name>.snap` where
 the `name` of the snapshot. Snapshots can either be explicitly named or the
 name is derived from the test name.
 


### PR DESCRIPTION
I spent a few hours today trying different options to put the snapshots folder out of the `src` folder but wanted to test some private functions and had a hard time finding a good way. Eventually found the settings option much later while looking for something else. The website is so much more inviting that I wasn't using docs.rs much and didn't realize that the information that would have helped so much was there. The current way it is stated on the website doesn't make it sound configurable.