### PR TITLE
Fix filters docs

### DIFF
--- a/content/docs/filters.md
+++ b/content/docs/filters.md
@@ -9,12 +9,12 @@ weight = 7
 
 Similar to [redactions](../redactions/) insta also supports filtering of snapshots.
 These are regular expressions applied to the actual snapshot content to normalize
-input before they are persisted to disk.  Filters are an optional feature and
+input before they are persisted to disk. Filters are an optional feature and
 can be enabled with the `filters` feature.
 
-Redactions can be only defined via settings.  They are individually added with
-`Settings::add_filter` or by using the `with_settings!` macro.  The first argument
-is the regex, the second is the replacement string.  When set with `with_settings!`
+Filters can be only defined via settings. They are individually added with
+`Settings::add_filter` or by using the `with_settings!` macro. The first argument
+is the regex, the second is the replacement string. When set with `with_settings!`
 a vector of tuples is expected:
 
 ```rust


### PR DESCRIPTION
This mistakenly has "Redactions".

My autoformatter also cleared up some double spaces. I can revert if that's annoying.