### PR TITLE
fixup macro invocation syntax

### DIFF
--- a/content/docs/cmd.md
+++ b/content/docs/cmd.md
@@ -94,7 +94,7 @@ And then you can use it as such:
 ```rust
 #[test]
 fn test_basic() {
-    apply_common_filters();
+    apply_common_filters!();
     assert_cmd_snapshot!(cli().arg("create-temp-file").arg("--template=./foo"), @###"
     success: true
     exit_code: 0


### PR DESCRIPTION
Thank you for adding a link on the page to easily submit PR suggestions!

This is a very tiny change.   I noticed the macro invocation was missing the macro sigil (`!`).   It seems unfortunate the book is not easily runnable as a doctest, but fixes are easy enough to request.
