### PR TITLE
ci: redeploy site daily to refresh changelog

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,12 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  # Rebuild periodically so /changelog/ picks up CHANGELOG.md from mitsuhiko/insta
+  # (fetched at build time via the fetch_github shortcode).
+  schedule:
+    - cron: "0 6 * * *"
+  repository_dispatch:
+    types: [sync-changelog]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 This is the website for the insta snapshotting tool.
 
 It is built with [zola](https://www.getzola.org/).
+
+The [changelog](https://insta.rs/changelog/) page loads `CHANGELOG.md` from
+[`mitsuhiko/insta`](https://github.com/mitsuhiko/insta) at build time. The site
+is redeployed on pushes to `main`, daily on a schedule, via `workflow_dispatch`,
+or when the insta repo sends a `repository_dispatch` event (`sync-changelog`).


### PR DESCRIPTION
## Summary

The changelog page (`content/changelog.md`) fetches `CHANGELOG.md` from `mitsuhiko/insta` at Zola build time, but the site was only redeployed when `insta-website` itself changed. After an insta release, https://insta.rs/changelog/ could stay stale until someone pushed here.

This adds:
- **Daily schedule** (06:00 UTC) to rebuild and deploy
- **`repository_dispatch`** (`sync-changelog`) so the insta repo can trigger a deploy when `CHANGELOG.md` changes (maintainers can wire a PAT + workflow in insta if desired)

Refs mitsuhiko/insta#896

## Test plan

- [x] Workflow YAML is valid (same jobs as existing push/workflow_dispatch triggers)
- [ ] After merge, confirm scheduled run appears under Actions