### PR TITLE
Rebuild site daily so the changelog page stays current

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  # Rebuild daily so the changelog page picks up new CHANGELOG.md entries from
+  # the insta repo, which are fetched at build time rather than committed here.
+  schedule:
+    - cron: '17 4 * * *'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The changelog page (`content/changelog.md`) fetches `CHANGELOG.md` from the insta repo at build time via the `fetch_github` shortcode, so it only reflects new releases when the site is rebuilt. The deploy workflow runs on push to `main`, on PRs, and on manual dispatch, none of which fire when a release lands in the insta repo. As a result the published changelog had fallen several versions behind (mitsuhiko/insta#896).

This adds a daily `schedule` trigger to the deploy workflow. Scheduled runs use `refs/heads/main`, so the existing `build_and_deploy` job runs and re-fetches the changelog; the PR-preview `build` job is skipped as before.

Two caveats:

- The cron only takes effect once this is on `main`. A one-off `workflow_dispatch` run clears the current backlog immediately.
- `zola-deploy-action` force-pushes `gh-pages` on every run, so there will be a daily deploy commit even when nothing changed. An event-driven trigger (`repository_dispatch` from the insta release flow) would avoid that, at the cost of changes in both repos.

Closes mitsuhiko/insta#896. Thanks to @killercup for reporting.

> _This was written by Claude Code on behalf of max_
