### PR TITLE
Skip deploy when the built site is unchanged

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,29 @@ jobs:
         uses: actions/checkout@main
       - name: 'Fetch Installers'
         run: make fetch-installers
-      - name: 'Build and deploy'
+      - name: 'Build'
+        uses: shalzz/zola-deploy-action@71190a69bbadd5fea222346d79b960e687e898ed
+        env:
+          BUILD_DIR: .
+          BUILD_ONLY: true
+      # The deploy action force-pushes gh-pages on every run, so a scheduled
+      # rebuild commits even when nothing changed. Skip the deploy when the
+      # freshly built site is identical to what's already published.
+      - name: 'Check for changes'
+        id: diff
+        run: |
+          rm -rf ../published && mkdir -p ../published
+          if git fetch --depth=1 origin gh-pages 2>/dev/null; then
+            git archive FETCH_HEAD | tar -x -C ../published
+          fi
+          if diff -rq ../published public >/dev/null 2>&1; then
+            echo "Built site matches the published one; skipping deploy."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: 'Deploy'
+        if: steps.diff.outputs.changed == 'true'
         uses: shalzz/zola-deploy-action@71190a69bbadd5fea222346d79b960e687e898ed
         env:
           PAGES_BRANCH: gh-pages


### PR DESCRIPTION
Follow-up to #36. The daily `schedule` keeps the changelog current, but `shalzz/zola-deploy-action` re-inits `public/` and force-pushes `gh-pages` on every run with no diff check, so each scheduled rebuild produced a deploy commit even when nothing had changed.

This splits `build_and_deploy` into build, diff, and deploy:

1. **Build** runs the action in `BUILD_ONLY` mode to produce `public/` without pushing.
2. **Check for changes** fetches the published `gh-pages`, expands it, and `diff -rq`s it against the fresh `public/`.
3. **Deploy** runs the action's full build-and-push, gated on `steps.diff.outputs.changed == 'true'`.

An unchanged site now builds, compares, and exits without touching `gh-pages`. The gate applies to every trigger, not just the cron, so a push that doesn't alter the rendered output also won't redeploy. This relies on Zola's output being deterministic, which holds here: the config generates no feeds and embeds no dates, so identical inputs produce a byte-identical `public/`.

Two things worth knowing:

- The `build_and_deploy` job only runs on `main`, the schedule, and manual dispatch, so PR CI exercises the `build` job but not the new diff and deploy steps. The diff logic was checked with actionlint and locally; the deploy path first runs after merge. To confirm it, run the workflow via `workflow_dispatch` twice: the second run should log "Built site matches the published one; skipping deploy."
- If the build output were ever non-deterministic, the diff would always report a change and it would deploy every run, matching the previous behavior. So the failure mode is safe.

> _This was written by Claude Code on behalf of max_
